### PR TITLE
Make the API chainable

### DIFF
--- a/lib/jQuery.toggleModifier.js
+++ b/lib/jQuery.toggleModifier.js
@@ -87,14 +87,17 @@
 
   $.fn.toggleModifier = function(modifier) {
     modify($(this), methods.__toggle, modifier);
+    return this;
   };
 
   $.fn.addModifier = function(modifier) {
     modify($(this), methods.__add, modifier);
+    return this;
   };
 
   $.fn.removeModifier = function(modifier) {
     modify($(this), methods.__remove, modifier);
+    return this;
   };
 
   $.fn.hasModifier = function(modifier) {

--- a/tests/acceptance/general_behavior.js
+++ b/tests/acceptance/general_behavior.js
@@ -86,9 +86,16 @@ QUnit.test('Element has modifier', function(assert) {
     'The element has modifier');
 });
 
+
 QUnit.test('Element has not modifier', function(assert) {
   this.subject.addClass('block__element');
 
   assert.notOk(this.subject.hasModifier('modifier'),
     'The element has not modifier');
+});
+
+QUnit.test('Assert the chain for the modifier methods', function(assert) {
+  assert.deepEqual(this.subject.toggleModifier('modifier'), this.subject);
+  assert.deepEqual(this.subject.addModifier('modifier'), this.subject);
+  assert.deepEqual(this.subject.removeModifier('modifier'), this.subject);
 });


### PR DESCRIPTION
``` javascript
$('foo')
  .addModifier('bar')
  .removeModifier('bar');
```
